### PR TITLE
Strengthen homepage clarity and portfolio entrance

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,17 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Inkspirations Studios | Robert Marleton</title>
-  <meta name="description" content="Inkspirations Studios is Robert Marleton's public studio entry for artwork, writing, music, and interactive creative rooms.">
+  <title>Robert Marleton | Creative Director & Designer</title>
+  <meta name="description" content="Robert Marleton is the Founder and Creative Director of Inkspirations Studios, available for graphic design, branding, art direction, creative direction, and visual storytelling.">
   <meta name="robots" content="index,follow">
   <link rel="canonical" href="https://rm337.github.io/markdown-portfolio/">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://rm337.github.io/markdown-portfolio/">
+  <meta property="og:title" content="Robert Marleton | Creative Director & Designer">
+  <meta property="og:description" content="Explore selected work from Robert Marleton and Inkspirations Studios—graphic design, branding, art direction, creative direction, and visual storytelling.">
+  <meta property="og:image" content="https://rm337.github.io/markdown-portfolio/assets/images/portfolio/Fluid_Soul_Front_Cover_edited.png">
+  <meta property="og:image:alt" content="Fluid Soul artwork by Robert Marleton for Inkspirations Studios">
+  <meta name="twitter:card" content="summary_large_image">
   <link rel="icon" href="data:,">
   <link rel="stylesheet" href="style.css?v=20260630-complete">
 </head>
@@ -18,9 +25,9 @@
   </div>
   <!-- Navigation begins -->
   <nav class="nav" aria-label="Primary navigation">
-    <a class="brand" href="index.html#top">Inkspirations Studios</a>
+    <a class="brand" href="index.html#top" aria-current="page">Inkspirations Studios</a>
     <div class="links">
-      <a href="index.html#top">Home</a>
+      <a href="index.html#top" aria-current="page">Home</a>
       <a href="portfolio.html#portfolio">Portfolio</a>
       <a href="index.html#about">About</a>
       <a href="index.html#contact">Contact</a>
@@ -32,27 +39,53 @@
     <!-- Hero begins -->
     <header class="hero studio-entry">
       <div class="hero-copy">
-        <p class="kicker">Robert Marleton / Creative Studio</p>
-        <h1>Inkspirations Studios</h1>
-        <p class="welcome">A calm entry into Robert Marleton's artwork, writing, music, functional art, and interactive creative rooms.</p>
-        <p>This homepage is the studio lobby. Step into the portfolio when you are ready to explore the full Inkspirations world.</p>
+        <p class="kicker">Robert Marleton / Founder & Creative Director</p>
+        <h1>Creative work with feeling, clarity, and purpose.</h1>
+        <p class="welcome">Inkspirations Studios is the creative home of Robert Marleton—graphic designer, brand thinker, art director, creative director, and visual storyteller.</p>
+        <p>Available for freelance, contract, and full-time opportunities in graphic design, branding, art direction, creative direction, and visual storytelling.</p>
         <div class="actions">
-          <a class="btn primary" href="portfolio.html#portfolio">Enter the Gallery</a>
-          <a class="btn" href="index.html#contact">Contact Robert</a>
+          <a class="btn primary" href="portfolio.html#portfolio">View Selected Work</a>
+          <a class="btn" href="index.html#contact">Start a Conversation</a>
         </div>
       </div>
     </header>
     <!-- Hero ends -->
 
-
+    <!-- Selected work entrance begins -->
+    <section class="section world-section" aria-labelledby="selected-work-title">
+      <div class="section-head gallery-head">
+        <div>
+          <p class="kicker">Selected Work</p>
+          <h2 id="selected-work-title">Enter through the work.</h2>
+          <p>Begin with a signature artwork, then explore creative direction, brand presentation, functional art, writing, and the wider Inkspirations Studios world.</p>
+        </div>
+        <span class="meta">Curated Portfolio</span>
+      </div>
+      <div class="world-grid" aria-label="Selected portfolio entrances">
+        <a class="world-card featured-world" href="portfolio.html#portfolio">
+          <span class="room-kicker">Featured Artwork</span>
+          <strong>Fluid Soul</strong>
+          <span>A layered blue current of movement, texture, and emotion—the visual anchor of the Inkspirations Studios portfolio.</span>
+        </a>
+        <a class="world-card" href="portfolio.html#world">
+          <span class="room-kicker">Creative Practice</span>
+          <strong>Design, Direction & Story</strong>
+          <span>Explore Robert's approach to branding, visual systems, art direction, and thoughtful creative experiences.</span>
+        </a>
+      </div>
+      <div class="actions">
+        <a class="btn primary" href="portfolio.html#portfolio">Explore the Portfolio</a>
+      </div>
+    </section>
+    <!-- Selected work entrance ends -->
 
     <!-- About begins -->
     <section class="section" id="about">
       <div class="about-panel">
         <p class="kicker">About</p>
-        <h2>A creative home with room to enter.</h2>
-        <p>Inkspirations Studios gathers Robert's visual artwork, lettering, texture studies, functional art experiments, writing, music ideas, and interactive studio concepts into one calm public space.</p>
-        <p>The homepage stays quiet on purpose. Step deeper to find the artwork, writing, coasters, Ocean of Ink, listening rooms, and studio artifacts.</p>
+        <h2>A creative home built around curiosity and connection.</h2>
+        <p>Robert Marleton founded Inkspirations Studios to bring visual artwork, graphic design, branding, writing, music, functional art, and immersive storytelling into one connected creative practice.</p>
+        <p>The studio is calm by design: a welcoming place where individual pieces and larger ideas can be experienced with room to breathe.</p>
       </div>
     </section>
     <!-- About ends -->
@@ -62,10 +95,10 @@
       <div class="contact">
         <div>
           <p class="kicker">Contact</p>
-          <h2>Available for creative work.</h2>
-          <p>Artwork, commissions, writing, rooms, music atmosphere, and collaboration.</p>
+          <h2>Let’s create something meaningful.</h2>
+          <p>Robert is available for graphic design, branding, art direction, creative direction, visual storytelling, commissions, collaborations, contract work, and full-time opportunities.</p>
         </div>
-        <a class="btn primary" href="mailto:r.marleton@gmail.com?subject=Inkspirations%20Studios%20Portfolio">Get in Touch</a>
+        <a class="btn primary" href="mailto:r.marleton@gmail.com?subject=Creative%20Work%20Inquiry%20for%20Robert%20Marleton">Contact Robert</a>
       </div>
     </section>
     <!-- Contact ends -->
@@ -74,9 +107,8 @@
   <footer>
     <span>Inkspirations Studios</span>
     <span>Robert Marleton</span>
-    <span>Studio Entry</span>
+    <span>Founder & Creative Director</span>
   </footer>
   <script src="studio-audio.js?v=20260630-audio-safe"></script>
 </body>
 </html>
-

--- a/portfolio.html
+++ b/portfolio.html
@@ -3,10 +3,17 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Inkspirations Gallery | Inkspirations Studios</title>
-  <meta name="description" content="A polished visual portfolio gallery for selected Inkspirations Studios artwork by Robert Marleton.">
+  <title>Selected Work | Robert Marleton</title>
+  <meta name="description" content="Explore selected artwork, creative direction, brand presentation, and functional art concepts by Robert Marleton and Inkspirations Studios.">
   <meta name="robots" content="index,follow">
   <link rel="canonical" href="https://rm337.github.io/markdown-portfolio/portfolio.html">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://rm337.github.io/markdown-portfolio/portfolio.html">
+  <meta property="og:title" content="Selected Work | Robert Marleton">
+  <meta property="og:description" content="A curated portfolio of artwork, creative direction, branding, visual storytelling, and functional art by Robert Marleton.">
+  <meta property="og:image" content="https://rm337.github.io/markdown-portfolio/assets/images/portfolio/Fluid_Soul_Front_Cover_edited.png">
+  <meta property="og:image:alt" content="Fluid Soul artwork by Robert Marleton for Inkspirations Studios">
+  <meta name="twitter:card" content="summary_large_image">
   <link rel="icon" href="data:,">
   <link rel="stylesheet" href="style.css?v=20260709-focused-portfolio">
 </head>
@@ -19,7 +26,7 @@
     <a class="brand" href="index.html#top">Inkspirations Studios</a>
     <div class="links">
       <a href="index.html#top">Home</a>
-      <a href="portfolio.html#portfolio">Portfolio</a>
+      <a href="portfolio.html#portfolio" aria-current="page">Portfolio</a>
       <a href="portfolio-gallery.html">Interactive Gallery</a>
       <a href="index.html#about">About</a>
       <a href="index.html#contact">Contact</a>
@@ -29,17 +36,17 @@
   <main id="top">
     <header class="hero studio-entry gallery-entry">
       <div class="hero-copy">
-        <p class="kicker">Inkspirations Gallery</p>
-        <h1>Robert Marleton Gallery</h1>
-        <p class="welcome">A focused public portfolio for artwork, creative direction, brand presentation, and functional art concepts.</p>
-        <p>This gallery is intentionally curated. It leads with the strongest verified artwork image currently in the repository and supports it with clear studio directions instead of padded or broken image placeholders.</p>
-        <div class="gallery-mood" aria-label="Gallery notes">
-          <span>Selected Work</span><span>Clean Public View</span><span>Employer Friendly</span>
+        <p class="kicker">Selected Work / Robert Marleton</p>
+        <h1>Art, design, and creative direction with a human pulse.</h1>
+        <p class="welcome">A curated portfolio of artwork, brand presentation, visual storytelling, creative direction, and functional art concepts.</p>
+        <p>Each entry offers a clear view into Robert's creative practice—how atmosphere, emotion, structure, and storytelling come together.</p>
+        <div class="gallery-mood" aria-label="Portfolio qualities">
+          <span>Selected Work</span><span>Creative Direction</span><span>Visual Storytelling</span>
         </div>
         <div class="actions">
-          <a class="btn primary" href="#portfolio">View the Gallery</a>
+          <a class="btn primary" href="#portfolio">View Selected Work</a>
           <a class="btn" href="portfolio-gallery.html">Open Interactive Gallery</a>
-          <a class="btn" href="index.html#contact">Contact Robert</a>
+          <a class="btn" href="index.html#contact">Work With Robert</a>
           <button class="btn audio-toggle" type="button" data-audio-toggle aria-pressed="false">Rainstorm Sound</button>
         </div>
       </div>
@@ -50,7 +57,7 @@
         <div>
           <p class="kicker">Studio Journey</p>
           <h2>A clear path through the work.</h2>
-          <p>The visitor sees the artwork first, then the studio identity, creative direction, writing, and functional art paths.</p>
+          <p>Begin with selected artwork, then move through creative direction, writing, functional art, and the atmospheric rooms that connect the studio.</p>
         </div>
         <span class="meta">Curated Path</span>
       </div>
@@ -59,12 +66,12 @@
         <a class="world-card featured-world" href="#portfolio">
           <span class="room-kicker">Artwork</span>
           <strong>Artwork Gallery</strong>
-          <span>Finished visual work and supporting portfolio directions presented without exposing internal systems.</span>
+          <span>Finished visual work and selected creative projects presented with space, context, and care.</span>
         </a>
         <a class="world-card" href="portfolio-gallery.html">
           <span class="room-kicker">Interactive</span>
           <strong>Interactive Gallery</strong>
-          <span>Search, filter, and open selected work in a larger lightbox gallery.</span>
+          <span>Search, filter, and open selected work in a larger gallery experience.</span>
         </a>
         <a class="world-card" href="#writing">
           <span class="room-kicker">Words</span>
@@ -74,7 +81,7 @@
         <a class="world-card" href="#functional">
           <span class="room-kicker">Functional Art</span>
           <strong>Functional Art Concepts</strong>
-          <span>Product-minded creative direction for objects, coasters, and usable surfaces.</span>
+          <span>Creative direction for objects, coasters, and useful pieces designed to live with people.</span>
         </a>
         <a class="world-card" href="rooms.html#ocean-of-ink">
           <span class="room-kicker">Atmosphere</span>
@@ -93,8 +100,8 @@
       <div class="section-head gallery-head">
         <div>
           <p class="kicker">Artwork</p>
-          <h2>Selected work, clearly presented.</h2>
-          <p>A focused gallery view for employers and clients. Open a card to see the piece larger and read the portfolio note.</p>
+          <h2>Selected work, thoughtfully presented.</h2>
+          <p>Open a piece to see it larger, read its story, and learn how to inquire about artwork, commissions, or creative collaboration.</p>
         </div>
         <span class="meta" id="galleryCount">Gallery</span>
       </div>
@@ -122,7 +129,7 @@
         <div>
           <p class="kicker">Writing / Poem</p>
           <h2>Robert's Poem</h2>
-          <p>A visible writing feature for the poem and the language side of Inkspirations Studios.</p>
+          <p>A small doorway into the reflective, language-driven side of Inkspirations Studios.</p>
         </div>
         <article class="poem-card" aria-label="Robert's poem">
           <span class="slot-label">Studio Poem</span>
@@ -141,12 +148,12 @@
         <div>
           <p class="kicker">Functional Art</p>
           <h2>Objects people can live with.</h2>
-          <p>This section keeps the product direction public-facing without pretending unfinished or missing photos are ready. Future coaster and object photos can be added here when the final images are confirmed.</p>
+          <p>Inkspirations Studios explores how artwork can move beyond the wall and become part of everyday life through coasters, surfaces, and thoughtfully designed objects.</p>
         </div>
         <div class="slot-grid" aria-label="Functional art directions">
           <article class="asset-slot"><span>Coaster Direction</span><strong>Blue Current Coasters</strong><small>Functional art concept</small></article>
           <article class="asset-slot"><span>Surface Study</span><strong>Usable Studio Objects</strong><small>Product-minded artwork</small></article>
-          <article class="asset-slot"><span>Future Photos</span><strong>Ready When Verified</strong><small>No broken placeholders</small></article>
+          <article class="asset-slot"><span>Custom Work</span><strong>Made for Your Space</strong><small>Commission inquiries welcome</small></article>
         </div>
         <div class="actions">
           <a class="btn primary" href="index.html#contact">Ask About Functional Art</a>
@@ -160,7 +167,7 @@
         <div>
           <p class="kicker">Rooms To Enter</p>
           <h2>Rooms that open into the studio.</h2>
-          <p>Studio rooms, listening spaces, writing paths, and atmosphere are gathered here as places to enter after the main portfolio.</p>
+          <p>Writing, music, atmosphere, and deeper studio spaces invite visitors to experience the wider creative world behind the selected work.</p>
         </div>
         <span class="meta">Rooms</span>
       </div>
@@ -169,7 +176,7 @@
         <a class="room-card featured-room" href="rooms.html#ocean-of-ink"><span class="room-kicker">Ocean of Ink</span><strong>Ocean Room</strong><span>The blue ink atmosphere that connects the rooms.</span></a>
         <a class="room-card" href="rooms.html#writing-room"><span class="room-kicker">Writing</span><strong>Writing Room</strong><span>A quiet path into Robert's words and reflective studio voice.</span></a>
         <a class="room-card" href="rooms.html#music-room"><span class="room-kicker">Music</span><strong>Music Room</strong><span>A softer doorway into the listening side of Inkspirations Studios.</span></a>
-        <a class="room-card" href="rooms.html"><span class="room-kicker">Explore</span><strong>Enter the Rooms</strong><span>Move deeper only after meeting the artwork, writing, and atmosphere.</span></a>
+        <a class="room-card" href="rooms.html"><span class="room-kicker">Explore</span><strong>Enter the Rooms</strong><span>Move deeper after meeting the artwork, writing, and atmosphere.</span></a>
       </div>
     </section>
   </main>
@@ -177,7 +184,7 @@
   <footer>
     <span>Inkspirations Studios</span>
     <span>Robert Marleton</span>
-    <span>Inkspirations Gallery</span>
+    <span>Selected Work</span>
   </footer>
 
   <div class="modal" id="modal" role="dialog" aria-modal="true" aria-label="Expanded artwork">

--- a/portfolio.json
+++ b/portfolio.json
@@ -1,6 +1,6 @@
 {
-  "updated": "2026-07-09",
-  "note": "Public gallery source. Keep this focused on verified, visitor-ready portfolio entries. Do not list image paths unless the asset is confirmed in the repository.",
+  "updated": "2026-07-10",
+  "note": "Curated portfolio entries for the public Inkspirations Studios gallery.",
   "works": [
     {
       "type": "Featured Artwork",
@@ -17,7 +17,7 @@
       "printAvailable": false,
       "originalAvailable": false,
       "inquiryType": "prints",
-      "desc": "A finished Inkspirations Studios artwork used as the main visual anchor for the portfolio. Its blue current, layered texture, and emotional tone establish the public studio identity."
+      "desc": "A layered blue current of movement, texture, and emotion. Fluid Soul serves as a visual anchor for Inkspirations Studios and reflects Robert's interest in artwork that feels atmospheric, immersive, and alive."
     },
     {
       "type": "Creative Direction",
@@ -31,7 +31,7 @@
       "printAvailable": false,
       "originalAvailable": false,
       "inquiryType": "creative-direction",
-      "desc": "A calm blue studio world built around ink, water, memory, and discovery. This entry shows Robert's ability to organize artwork into a clear visual experience instead of a loose folder of images."
+      "desc": "A calm blue creative world shaped around ink, water, memory, and discovery. The project demonstrates Robert's approach to organizing atmosphere, artwork, and storytelling into one connected visual experience."
     },
     {
       "type": "Brand Presentation",
@@ -45,7 +45,7 @@
       "printAvailable": false,
       "originalAvailable": false,
       "inquiryType": "branding",
-      "desc": "A public-facing creative identity shaped through consistent color, atmosphere, navigation, titles, and a museum-like visitor path."
+      "desc": "A creative identity shaped through color, atmosphere, navigation, titles, and a museum-like visitor journey. The system balances clarity with a distinctive emotional sense of place."
     },
     {
       "type": "Functional Art Direction",
@@ -61,7 +61,7 @@
       "printAvailable": false,
       "originalAvailable": false,
       "inquiryType": "functional-art",
-      "desc": "A product-minded direction for coaster sets, usable surfaces, and studio objects. It signals how Inkspirations artwork can extend into physical pieces without overloading the public gallery."
+      "desc": "A product-minded exploration of coaster sets, usable surfaces, and studio objects—showing how Inkspirations artwork can move beyond the wall and become part of everyday life."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Implements approved issue #24 with a small, reversible set of visitor-facing improvements.

### What changed
- Clarified above-the-fold positioning for Robert Marleton as Founder and Creative Director.
- Added explicit availability for graphic design, branding, art direction, creative direction, visual storytelling, freelance, contract, and full-time work.
- Strengthened the homepage calls to action and added a curated selected-work entrance using the existing museum-like visual system.
- Added Open Graph and large-image social sharing metadata using the verified `Fluid Soul` repository image.
- Rewrote portfolio copy that sounded technical or internal so it now speaks directly to visitors.
- Refined public portfolio descriptions without inventing artwork, projects, or image assets.
- Added `aria-current` to the active navigation links and preserved existing semantic controls and accessible button sizing.

## Files changed
- `index.html`
- `portfolio.html`
- `portfolio.json`

## Validation
- Confirmed the branch is based on `main` and contains only the three intended files.
- Reviewed the revised structure against the existing desktop and mobile breakpoints in `style.css`; the new homepage entrance deliberately reuses existing responsive `section`, `world-grid`, `world-card`, `actions`, and button styles.
- Reviewed navigation, headings, calls to action, modal labels, gallery controls, image alt text, and Open Graph image references for accessibility and path consistency.
- No CSS or JavaScript changes were required because the existing responsive and interactive systems already support the revised markup.

A live visual browser preview was not available in the connected workspace, so Robert should complete the final visual desktop/mobile review before merge.

## Constraints preserved
- No full redesign.
- No invented portfolio work or broken placeholders.
- No backend, AI, JSON mechanics, or implementation language exposed to visitors.
- No merge performed.

Closes #24 after approval and merge.